### PR TITLE
Fix Twitter/GitHub links on homepage

### DIFF
--- a/pages/index.js
+++ b/pages/index.js
@@ -3,7 +3,7 @@ import Link from 'next/link'
 const MainLink = ({ href, as, children }) => (
   <span>
     {href.startsWith('http')? (
-      <a>{children}</a>
+      <a href={href}>{children}</a>
     ) : (
       <Link href={href} as={as}>
         <a>{children}</a>


### PR DESCRIPTION
Twitter and GitHub links had no destination, as `MainLink` wasn't passing the `href` for external links. 😊